### PR TITLE
Added DF-SCF using BLAS and Cocc matrix

### DIFF
--- a/SCF/lac_df_scf_diis_cmat.dat
+++ b/SCF/lac_df_scf_diis_cmat.dat
@@ -111,7 +111,7 @@ for SCF_iter in range(1,psi4.get_global_option('MAXITER')+1):
         xp = np.dot(np.reshape(Qpq,(-1,main_nbf*main_nbf)),np.reshape(D,main_nbf*main_nbf))
         J = np.dot(np.reshape(Qpq.T,(main_nbf*main_nbf,-1)),xp).reshape(main_nbf,main_nbf)
         # Exchange Object
-        zeta = np.dot(np.reshape(Qpq,(-1,main_nbf)),D.T).reshape(Qpq.shape)
+        # zeta = np.dot(np.reshape(Qpq,(-1,main_nbf)),D.T).reshape(Qpq.shape)
         # zeta = np.einsum('Prq,pq->Prp',Qpq,Cocc)
         zeta = np.dot(np.reshape(Qpq,(-1,main_nbf)),Cocc).reshape(aux_nbf,main_nbf,ndocc)
         #raise Exception("OK")

--- a/SCF/lac_df_scf_diis_cmat.dat
+++ b/SCF/lac_df_scf_diis_cmat.dat
@@ -1,0 +1,188 @@
+import numpy as np
+import math
+import time
+
+molecule mol {
+0 1
+O
+H 1 1.1
+H 1 1.1 2 104
+symmetry c1
+}
+
+set{
+    basis cc-pVTZ
+    scf_type df
+    df_basis_scf cc-pVTZ-jkfit
+    df_scf_guess false
+    guess core
+    maxiter 150
+    diis_max_vecs 10
+    diis_min_vecs 2
+    diis_start 1
+    e_convergence 1e-8
+    d_convergence 1e-6
+}
+
+# One-electron integrals and Core-Hamiltonian
+wfn = psi4.new_wavefunction(mol,psi4.get_global_option('BASIS'))
+t1 = time.time()
+mints = psi4.MintsHelper(wfn.basisset())
+S = np.asarray(mints.ao_overlap())
+T = np.asarray(mints.ao_kinetic())
+V = np.asarray(mints.ao_potential())
+H = T+V
+
+# Size of Main Basis Set
+main_nbf = S.shape[0]
+
+g_size = (main_nbf**4)*8/1.e9
+if g_size >1:
+    raise Exception("G tensor is too big!")
+
+# Two-electron integrals
+if (psi4.get_global_option('SCF_TYPE')=='DF'):
+    # This is a slight hack of Psi4, it was never ment to do this.
+    scf_e, scf_wfn = energy('SCF', return_wfn=True)
+    dfobj = DFTensor(scf_wfn, "DF_BASIS_SCF")
+    Qpq = np.asarray(dfobj.Qso())
+    # Size of Auxiliary Basis Set
+    aux_nbf = Qpq.shape[0]
+    # Build the density fitted version
+    #Idf = np.einsum('Qpq,Qrs->pqrs', Qpq, Qpq)
+    print ('SCF Type: DF')
+else:
+    g = np.asarray(mints.ao_eri())
+    print ('SCF Type: PK')
+
+# Number of Doubly Occupied Orbitals
+ndocc = int((sum(mol.Z(A) for A in range(mol.natom()))-mol.molecular_charge())/2)
+
+# Guess Type: GWH or CORE
+if (psi4.get_global_option('GUESS')=='GWH'):
+    F0 = np.zeros((H.shape[0],H.shape[0]))
+    for m in range(H.shape[0]):
+        for n in range(H.shape[0]):
+            if (m==n):
+                F0[m,m] = H[m,m]
+            else:
+                F0[m,n] = S[m,n]*0.875*(H[m,m]+H[n,n])
+    print ('Guess is GWH')
+else:
+    F0 = np.copy(H)
+    print ('Guess is CORE')
+
+# Orthonormalization of Fock Matrix
+eigval,eigvec = np.linalg.eigh(S)
+Shalf_eigval  = np.diag(eigval ** (-0.5))
+A = np.dot(eigvec,Shalf_eigval).dot(eigvec.T)
+Fp = np.dot(A.T,F0).dot(A)
+eigvals, C2 = np.linalg.eigh(Fp)
+C = np.dot(A,C2)
+
+# Density Matrix
+Cocc = C[:,:ndocc]
+D = np.dot(Cocc,Cocc.T)
+
+print('Total time taken for setup: %.3f seconds' % (time.time() - t1))
+
+print('\nStart SCF iterations:')
+t = time.time()
+
+# Nuclear Repulsion Energy
+#Enuc = 0
+#geom = np.asarray(mol.geometry())
+#for atomA in range(mol.natom()):
+#    for atomB in range(atomA+1,mol.natom()):
+#        Enuc+=mol.Z(atomA)*mol.Z(atomB)/sqrt((geom[atomA][0]-geom[atomB][0])**2+(geom[atomA][1]-geom[atomB][1])**2+(geom[atomA][2]-geom[atomB][2])**2)
+Enuc = mol.nuclear_repulsion_energy()
+
+# DIIS State and Error Vectors
+DIIS_S = []
+DIIS_R = []
+E_old = 0
+
+# SCF and DIIS iterations
+for SCF_iter in range(1,psi4.get_global_option('MAXITER')+1):
+
+    # Coulomb, Exchange matrices
+    if (psi4.get_global_option('SCF_TYPE')=='DF'):
+        # Coulomb Object
+        xp = np.dot(np.reshape(Qpq,(-1,main_nbf*main_nbf)),np.reshape(D,main_nbf*main_nbf))
+        J = np.dot(np.reshape(Qpq.T,(main_nbf*main_nbf,-1)),xp).reshape(main_nbf,main_nbf)
+        # Exchange Object
+        zeta = np.dot(np.reshape(Qpq,(-1,main_nbf)),D.T).reshape(Qpq.shape)
+        # zeta = np.einsum('Prq,pq->Prp',Qpq,Cocc)
+        zeta = np.dot(np.reshape(Qpq,(-1,main_nbf)),Cocc).reshape(aux_nbf,main_nbf,ndocc)
+        #raise Exception("OK")
+        K = np.dot(np.einsum('Pup->uPp',zeta).reshape(main_nbf,-1),np.einsum('Pvp->Ppv',zeta).reshape(-1,main_nbf))
+    else:
+        #J = np.einsum('pqrs,rs->pq', g,D)
+        J = np.dot(np.reshape(g,(main_nbf*main_nbf,-1)),np.reshape(D,main_nbf*main_nbf)).reshape(main_nbf,main_nbf)
+        #K = np.einsum('prqs,rs->pq',g,D)
+        K = np.dot(np.einsum('prqs->pqrs',g).reshape(main_nbf*main_nbf,-1),np.reshape(D,main_nbf*main_nbf)).reshape(main_nbf,main_nbf)
+    # Fock Matrix
+    F = H + 2*J - K
+
+
+    # SCF Energy
+    #Eelc = np.einsum('pq,pq->',H+F,D)
+    Eelc = np.dot(np.reshape(H+F,main_nbf*main_nbf),np.reshape(D,main_nbf*main_nbf))
+    E_scf = Eelc+Enuc
+    dE = E_scf-E_old
+
+
+    r = A.T.dot(F.dot(D).dot(S)-S.dot(D).dot(F)).dot(A)
+    dRMS = np.mean(r**2)**0.5
+
+    #DIIS Procedure
+    if (SCF_iter >= psi4.get_global_option('DIIS_START')):
+        DIIS_S.append(F)
+        dim_diis = len(DIIS_S)
+        if (dim_diis > psi4.get_global_option('DIIS_MAX_VECS')):
+            del DIIS_S[0]
+            del DIIS_R[0] 
+        dim_diis = len(DIIS_S)
+        DIIS_R.append(r)
+        if (dim_diis >= psi4.get_global_option('DIIS_MIN_VECS')):
+            B = np.zeros((dim_diis+1,dim_diis+1))
+            B[-1] = -1
+            B[:,-1] = -1
+            B[-1,-1] = 0
+            for i in range(dim_diis):
+                for j in range(dim_diis):
+                    B[i,j] = np.sum(DIIS_R[i]*DIIS_R[j])
+            b = np.zeros(dim_diis+1)
+            b[-1]=-1
+            diis_c = np.linalg.solve(B,b)
+            F = np.zeros_like(H)
+            for cx in range(diis_c.size-1):
+                F += diis_c[cx]*DIIS_S[cx]
+        
+
+    # Orthonormalization of Fock Matrix and SCF energy
+    Fp = np.dot(A.T,F).dot(A)
+    eigvals, C2 = np.linalg.eigh(Fp)
+    C = np.dot(A,C2)
+
+    Cocc = C[:,:ndocc]
+    D = np.dot(Cocc,Cocc.T)
+
+    E_old = E_scf
+
+    if (SCF_iter < psi4.get_global_option('DIIS_START') or dim_diis < psi4.get_global_option('DIIS_MIN_VECS')):
+        print ('SCF Iteration %2d: %12.14f        dE = %2.5E        dRMS = %2.5E'  % (SCF_iter, E_scf, dE, dRMS))
+    else:
+        print ('SCF Iteration %2d: %12.14f        dE = %2.5E        dRMS = %2.5E    DIIS'  % (SCF_iter, E_scf, dE, dRMS))
+    if (abs(dE) < psi4.get_global_option('E_CONVERGENCE') and abs(dRMS) < psi4.get_global_option('D_CONVERGENCE')):
+        print('SCF CONVERGED\n')
+        break
+    if (SCF_iter > psi4.get_global_option('MAXITER')):
+        raise Exception("Maximum number of iterations achieve without convergence")
+
+print('Total time for SCF iterations: %.3f seconds' % (time.time() - t))
+print('Total time for the program: %.3f seconds' %(time.time()-t1))
+print('\nElectronic energy is  %12.10f' % Eelc)
+print('Nuclear energy is %12.10f' % Enuc)
+print('Total Enegy is %12.10f' % (E_scf))
+print('Psi4 Total Energy is %12.10f' % (energy('scf')))


### PR DESCRIPTION
DF-SCF using np.dot to do tensor multiplications and C matrix to build K objetc. Some test cases with physicist water molecule:

1) Basis Set: cc-pVDZ and Core Guess
                   Setup Time      SCF iterations time      Total time
PK                  0.082 s                 0.017 s                   0.099 s 
DF                  0.127 s                 0.014s                   0.141 s

2) Basis Set: aug-cc-pVDZ and Core Guess
                   Setup Time      SCF iterations time      Total time
PK                  0.267 s                 0.123 s                   0.390 s 
DF                  0.163 s                 0.051 s                   0.215 s

3) Basis Set: cc-pVTZ and Core Guess
                   Setup Time      SCF iterations time      Total time
PK                  0.698 s                 0.471 s                   1.169 s 
DF                  0.193 s                 0.101 s                   0.294 s          

 4) Basis Set: aug-cc-pVTZ and Core Guess
                   Setup Time      SCF iterations time      Total time
PK                  3.462 s                 2.979 s                   6.441 s 
DF                  0.370 s                 0.381 s                   0.751 s   

 5) Basis Set: cc-pVQZ and Core Guess
                   Setup Time      SCF iterations time      Total time
PK                  9.298 s                 6.803 s                   16.100  s 
DF                  0.570 s                 0.663 s                   1.233 s   

 6) Basis Set: aug-cc-pVQZ and Core Guess
                   Setup Time      SCF iterations time      Total time
PK                  45.968 s               38.106 s                  84.074 s 
DF                  1.643 s                 3.091 s                   4.735 s   
